### PR TITLE
fix: Update model to gemini-flash-latest

### DIFF
--- a/src/app/mcp/api/route.ts
+++ b/src/app/mcp/api/route.ts
@@ -23,7 +23,7 @@ import { defineMcpClient, GenkitMcpClient } from "@genkit-ai/mcp";
 
 const ai = genkit({
   plugins: [googleAI()], // set the GOOGLE_API_KEY env variable
-  model: googleAI.model("gemini-2.5-flash"),
+  model: googleAI.model("gemini-flash-latest"),
 });
 
 let firebaseMcp: GenkitMcpClient;

--- a/src/common/genkit-beta.ts
+++ b/src/common/genkit-beta.ts
@@ -22,7 +22,7 @@ import { googleAI } from "@genkit-ai/google-genai";
 
 const ai = genkit({
   plugins: [googleAI()], // set the GOOGLE_API_KEY env variable
-  model: googleAI.model('gemini-2.5-flash'),
+  model: googleAI.model('gemini-flash-latest'),
 });
 
 // !!!END

--- a/src/common/genkit.ts
+++ b/src/common/genkit.ts
@@ -19,7 +19,7 @@ import { googleAI } from "@genkit-ai/google-genai";
 
 const ai = genkit({
   plugins: [googleAI()], // set the GOOGLE_API_KEY env variable
-  model: googleAI.model('gemini-2.5-flash'),
+  model: googleAI.model('gemini-flash-latest'),
 });
 
 // !!!END


### PR DESCRIPTION
Fixes the `404 Not Found` error on examples.genkit.dev when requesting from gemini-2.5-flash.
Forces the googleAI plugin to use the stable `apiVersion: 'v1'` endpoint in `genkit.ts`, `genkit-beta.ts`, and the MCP route configuration.